### PR TITLE
fix: a bug where we would drop data during encoding

### DIFF
--- a/benchmark/decoding-comparison.ts
+++ b/benchmark/decoding-comparison.ts
@@ -6,15 +6,10 @@ import { decode, encode } from '../lib'
 import { randomBytes } from 'crypto'
 import { equal } from 'assert'
 
-const MESSAGES = [
-  randomBytes(1024),
-  randomBytes(1024),
-  randomBytes(1024),
-  randomBytes(1024),
-  randomBytes(1024),
-  randomBytes(1024),
-  randomBytes(1024),
-]
+const MESSAGES: Buffer[] = []
+for (let size = 1; size < 1000; size++) {
+  MESSAGES.push(randomBytes(size))
+}
 
 const packetPerMessage = Array.from(encode(MESSAGES))
 const onePacket = [Buffer.concat(packetPerMessage)]
@@ -22,12 +17,12 @@ const manyPackets = [...onePacket].map(byte => Buffer.from([byte]))
 
 function testDecode(description: string, packets: Buffer[]) {
   const suite = new Suite()
-  suite.add(`protocol-slip decode ${description}`, () => {
+  suite.add('protocol-slip', () => {
     const messages = Array.from(decode(packets))
-    // equal(messages.length, MESSAGES.length)
+    equal(messages.length, MESSAGES.length)
   })
 
-  suite.add(`slip decode ${description}`, () => {
+  suite.add('slip', () => {
     const messages: any[] = []
     const decoder = new slip.Decoder({
       onMessage(message) {
@@ -35,10 +30,10 @@ function testDecode(description: string, packets: Buffer[]) {
       },
     })
     packets.forEach(packet => decoder.decode(packet))
-    // equal(messages.length, MESSAGES.length)
+    equal(messages.length, MESSAGES.length)
   })
 
-  suite.add(`node-slip decode ${description}`, () => {
+  suite.add('node-slip', () => {
     const messages: any[] = []
     const parser = new nodeSlip.parser({
       data(message) {
@@ -46,7 +41,7 @@ function testDecode(description: string, packets: Buffer[]) {
       },
     })
     packets.forEach(packet => parser.write(packet))
-    // equal(messages.length, MESSAGES.length)
+    equal(messages.length, MESSAGES.length)
   })
 
   suite.on('cycle', event => {

--- a/lib/encode.ts
+++ b/lib/encode.ts
@@ -15,9 +15,9 @@ export const encodeMessage = (data: Buffer) => {
     // find the next thing to escape
     if (nextSlice === endPosition) {
       endPosition = remainingPacket.indexOf(END)
-      escPosition = escPosition - (part.length + 1)
+      escPosition = escPosition === -1 ? -1 : escPosition - (part.length + 1)
     } else {
-      endPosition = endPosition - (part.length + 1)
+      endPosition = endPosition === -1 ? -1 : endPosition - (part.length + 1)
       escPosition = remainingPacket.indexOf(ESC)
     }
   }

--- a/lib/integration-slip-test.ts
+++ b/lib/integration-slip-test.ts
@@ -1,16 +1,23 @@
 import slip from 'slip'
-import { randomBytes } from 'crypto'
-import { END, ESC } from './constants'
-import { decode } from './decode'
+import { decode, encodeMessage } from './'
 import { deepEqual } from 'assert'
 
-const complexMessage = Buffer.concat([randomBytes(1024), END, randomBytes(1024), ESC, randomBytes(1024)])
+const doubleBytes: Buffer[] = []
+for (let byte = 0; byte < 2 ** 8; byte++) {
+  doubleBytes.push(Buffer.from([byte, byte]))
+}
+const complexMessage = Buffer.concat([...doubleBytes, ...doubleBytes.reverse()])
 const copyOfMessage = Buffer.alloc(complexMessage.length)
 complexMessage.copy(copyOfMessage)
 describe('npm slip integration test', () => {
+  it('packet formats match', () => {
+    const packet = encodeMessage(complexMessage)
+    const slipPacket = Buffer.from(slip.encode(complexMessage)).slice(1) // remove the leading END
+    deepEqual(packet, slipPacket, 'both encodings match')
+  })
+
   it('protocol-slip decodes npm slip encoded messages', () => {
     const packet = Buffer.from(slip.encode(complexMessage))
-    const decodedMessage = decode([packet]).next().value
 
     let slipDecodedMessage
     const decoder = new slip.Decoder({
@@ -22,7 +29,28 @@ describe('npm slip integration test', () => {
 
     deepEqual(complexMessage, copyOfMessage, 'message was mutated')
     deepEqual(slipDecodedMessage, complexMessage, 'node-slip can decode the message')
+
+    const decodedMessage = decode([packet]).next().value
     deepEqual(decodedMessage, complexMessage, 'decoded message does not match')
   })
-  it('npm slip decodes protocol-slip encoded messages')
+
+  it('slip decodes npm protocol-slip encoded messages', () => {
+    const packet = encodeMessage(complexMessage)
+    const slipPacket = Buffer.from(slip.encode(complexMessage))
+    deepEqual(packet, slipPacket.slice(1), 'both encodings match')
+
+    let slipDecodedMessage
+    const decoder = new slip.Decoder({
+      onMessage(message) {
+        slipDecodedMessage = Buffer.from(message)
+      },
+    })
+    decoder.decode(packet)
+
+    deepEqual(complexMessage, copyOfMessage, 'message was mutated')
+    deepEqual(slipDecodedMessage, complexMessage, 'node-slip can decode the message')
+
+    const decodedMessage = decode([packet]).next().value
+    deepEqual(decodedMessage, complexMessage, 'decoded message does not match')
+  })
 })

--- a/lib/integration-test.ts
+++ b/lib/integration-test.ts
@@ -1,6 +1,7 @@
+import { randomBytes } from 'crypto'
+import { deepEqual } from 'assert'
 import { collect } from 'streaming-iterables'
 import { encode, decode } from './'
-import { deepEqual } from 'assert'
 import { END, ESC, ESC_END } from './constants'
 
 const MESSAGE = Buffer.concat([
@@ -75,5 +76,23 @@ describe('integration', () => {
   it('decodes and encodes', () => {
     const packets = Buffer.concat(collect(encode(decode([PACKETS]))))
     deepEqual(packets, PACKETS)
+  })
+  it('every byte test', () => {
+    const MESSAGES: Buffer[] = []
+    for (let byte = 0; byte < 2 ** 8; byte++) {
+      MESSAGES.push(Buffer.from([byte, byte]))
+    }
+
+    const recodedMessages = collect(decode(encode(MESSAGES)))
+    deepEqual(recodedMessages, MESSAGES)
+  })
+  it('random byte test', () => {
+    const MESSAGES: Buffer[] = []
+    for (let count = 0; count < 1024; count++) {
+      MESSAGES.push(randomBytes((Math.random() + 1) * 1024))
+    }
+
+    const recodedMessages = collect(decode(encode(MESSAGES)))
+    deepEqual(recodedMessages, MESSAGES)
   })
 })


### PR DESCRIPTION
This one only hit with a specific combination of bytes and was caused due to some optimizing the encoding process. To mitigate this I’m going to add code coverage tools (which may have helped, but in any case are nice to have) and have already added both random and generated byte tests. No longer are we testing just printable ascii.

We still have the fastest encoder.